### PR TITLE
Remove trailing whitespace from password

### DIFF
--- a/GiftcardSite/k8/django-deploy.yaml
+++ b/GiftcardSite/k8/django-deploy.yaml
@@ -21,7 +21,7 @@ spec:
             - containerPort: 8000
           env:
             - name: MYSQL_ROOT_PASSWORD
-              value: thisisatestthing. 
+              value: thisisatestthing.
 
             - name: MYSQL_DB
               value: GiftcardSiteDB


### PR DESCRIPTION
Removes trailing whitespace from the `MYSQL_ROOT_PASSWORD`. Initially I thought the space was part of the password but it is not.